### PR TITLE
fix: incorrect field and missing require

### DIFF
--- a/lib/service2Paths.js
+++ b/lib/service2Paths.js
@@ -1,4 +1,5 @@
 const bakeRef = require('./bakeRef');
+const field2JSON = require('./field2JSON');
 
 function type2Parameters(type, paramIn = 'query') {
   return type.fieldsArray.map((field) => {
@@ -12,7 +13,7 @@ function type2Parameters(type, paramIn = 'query') {
     if (field.type === 'string') {
       ret = {
         ...ret,
-        ...field2JSON(type),
+        ...field2JSON(field),
       };
     } else {
       ret = {


### PR DESCRIPTION
Fix the following issues:
- `field` should be passed to `field2JSON` instead of `type`
- `field2JSON` isn't imported