### PR TITLE
Fix enum doc and provide a way to convert enum to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ module.exports = {
         break;
       }
       case 'enum': {
-        const [enum] = args;
-        console.log('enum:', enum);
-        break;
+        const [Enum] = args;
+        console.log('enum:', Enum);
+        return { ...result, type: 'string', enum: Object.keys(Enum.values) };
       }
       case 'service': {
         const [service, root, options] = args;


### PR DESCRIPTION
Before:
* default value `number`
`{
        "type": "number",
        "enum": [
          0,
          1,
          2,
          3,
          4
        ],
        "description": "0 - SELECTED_FOR_DISPATCH \n1 - DISPATCHING_AGENT \n2 - DISPATCHED_AGENT \n3 - DISPATCHING_CALLER \n4 - DISPATCHED_CALLER "
      }`
* tranform enum to `string`
`{
        "type": "string",
        "enum": [
          "SELECTED_FOR_DISPATCH",
          "DISPATCHING_AGENT",
          "DISPATCHED_AGENT",
          "DISPATCHING_CALLER",
          "DISPATCHED_CALLER"
        ],
        "description": "0 - SELECTED_FOR_DISPATCH \n1 - DISPATCHING_AGENT \n2 - DISPATCHED_AGENT \n3 - DISPATCHING_CALLER \n4 - DISPATCHED_CALLER "
      },`